### PR TITLE
Implement accurate-aiming CVAR in 3zb2 game code.

### DIFF
--- a/src/g_ctf.c
+++ b/src/g_ctf.c
@@ -1290,7 +1290,7 @@ void CTFGrappleDrawCable(edict_t *self)
 	{
 		AngleVectors (self->owner->client->v_angle, f, r, NULL);
 		VectorSet(offset, 16, 16, self->owner->viewheight-8);
-		P_ProjectSource (self->owner->client, self->owner->s.origin, offset, f, r, start);
+		P_ProjectSource (self->owner, offset, f, r, start);
 	}
 	else
 	{
@@ -1519,7 +1519,7 @@ void CTFGrappleFire (edict_t *ent, vec3_t g_offset, int damage, int effect)
 //	VectorSet(offset, 24, 16, ent->viewheight-8+2);
 	VectorSet(offset, 24, 8, ent->viewheight-8+2);
 	VectorAdd (offset, g_offset, offset);
-	P_ProjectSource (ent->client, ent->s.origin, offset, forward, right, start);
+	P_ProjectSource (ent, offset, forward, right, start);
 
 	VectorScale (forward, -2, ent->client->kick_origin);
 	ent->client->kick_angles[0] = -1;

--- a/src/g_main.c
+++ b/src/g_main.c
@@ -51,6 +51,8 @@ cvar_t	*bob_roll;
 
 cvar_t	*sv_cheats;
 
+cvar_t  *aimfix;
+
 //ponpoko
 cvar_t	*gamepath;
 cvar_t	*chedit;

--- a/src/g_save.c
+++ b/src/g_save.c
@@ -203,6 +203,9 @@ void InitGame (void)
 	bob_pitch = gi.cvar ("bob_pitch", "0.002", 0);
 	bob_roll = gi.cvar ("bob_roll", "0.002", 0);
 
+	/* others */
+	aimfix = gi.cvar("aimfix", "0", CVAR_ARCHIVE);
+
 	// items
 	InitItems ();
 

--- a/src/header/local.h
+++ b/src/header/local.h
@@ -576,6 +576,8 @@ extern	cvar_t	*maxspectators;
 
 extern	cvar_t	*filterban;
 
+extern  cvar_t  *aimfix;
+
 //ponpoko
 extern	cvar_t	*gamepath;
 extern	cvar_t	*chedit;
@@ -834,7 +836,7 @@ void DeathmatchScoreboardMessage (edict_t *client, edict_t *killer);
 // g_pweapon.c
 //
 void PlayerNoise(edict_t *who, vec3_t where, int type);
-void P_ProjectSource (gclient_t *client, vec3_t point, vec3_t distance, vec3_t forward, vec3_t right, vec3_t result);
+void P_ProjectSource (edict_t *ent, vec3_t distance, vec3_t forward, vec3_t right, vec3_t result);
 void Weapon_Generic (edict_t *ent, int FRAME_ACTIVATE_LAST, int FRAME_FIRE_LAST, int FRAME_IDLE_LAST, int FRAME_DEACTIVATE_LAST, int *pause_frames, int *fire_frames, void (*fire)(edict_t *ent));
 
 


### PR DESCRIPTION
3zb2-specific implementation of the changes in baseq2 PR [#561](https://github.com/yquake2/yquake2/pull/561).

This has been successfully build locally with GCC 9.3.0 but not gameplay tested as I don't have the PAK file(s) on-hand.